### PR TITLE
Fix timer channels for ATtinyX41

### DIFF
--- a/avr/cores/tiny/core_pins.h
+++ b/avr/cores/tiny/core_pins.h
@@ -63,10 +63,10 @@
 // TODO: ATtiny841 Datasheet Table 12-7, TOCCn pins can be assigned various OCnX. Rationale for these choices is that - TOCC0/1 are the primary pins for UART0, while TOCC3/4 are shared with UART1. So might as well make them the least desirable timer. 
 #define CORE_OC0A_PIN  PIN_A4 // TOCC3 
 #define CORE_OC0B_PIN  PIN_A5 // TOCC4 
-#define CORE_OC1A_PIN  PIN_A3 // TOCC2
-#define CORE_OC1B_PIN  PIN_A6 // TOCC5
-#define CORE_OC2A_PIN  PIN_A7 // TOCC6
-#define CORE_OC2B_PIN  PIN_B2 // TOCC7
+#define CORE_OC1A_PIN  PIN_A6 // TOCC5
+#define CORE_OC1B_PIN  PIN_A3 // TOCC2
+#define CORE_OC2A_PIN  PIN_B2 // TOCC7
+#define CORE_OC2B_PIN  PIN_A7 // TOCC6
 
 #define CORE_PWM0_PIN       CORE_OC0A_PIN
 #define CORE_PWM0_TIMER     0
@@ -78,19 +78,19 @@
 
 #define CORE_PWM2_PIN       CORE_OC1A_PIN
 #define CORE_PWM2_TIMER     1
-#define CORE_PWM2_CHANNEL   B //can't figure out why these need to be swapped, but they seem to :-/ 
+#define CORE_PWM2_CHANNEL   A
 
 #define CORE_PWM3_PIN       CORE_OC1B_PIN
 #define CORE_PWM3_TIMER     1
-#define CORE_PWM3_CHANNEL   A
+#define CORE_PWM3_CHANNEL   B
 
 #define CORE_PWM4_PIN       CORE_OC2A_PIN
 #define CORE_PWM4_TIMER     2
-#define CORE_PWM4_CHANNEL   B
+#define CORE_PWM4_CHANNEL   A
 
 #define CORE_PWM5_PIN       CORE_OC2B_PIN
 #define CORE_PWM5_TIMER     2
-#define CORE_PWM5_CHANNEL   A
+#define CORE_PWM5_CHANNEL   B
 
 #define CORE_PWM_COUNT      (6)
 

--- a/avr/cores/tiny/pins_arduino.c
+++ b/avr/cores/tiny/pins_arduino.c
@@ -250,12 +250,12 @@ const uint8_t PROGMEM digital_pin_to_bit_mask_PGM[] =
 //{
 //  NOT_ON_TIMER,
 //  NOT_ON_TIMER,
-//  TIMER2B, /* TOCC7 */
-//  TIMER2A, /* TOCC6 */
-//  TIMER1B, /* TOCC5 */
-//  TIMER0A, /* TOCC4 - this is shared with serial 1*/
-//  TIMER0B, /* TOCC3 - this is shared with serial 1 so let's give it the least desirable timer */
-//  TIMER1A, /* TOCC2 */
+//  TIMER2A, /* TOCC7 */
+//  TIMER2B, /* TOCC6 */
+//  TIMER1A, /* TOCC5 */
+//  TIMER0B, /* TOCC4 - this is shared with serial 1*/
+//  TIMER0A, /* TOCC3 - this is shared with serial 1 so let's give it the least desirable timer */
+//  TIMER1B, /* TOCC2 */
 //  NOT_ON_TIMER, //This could have pwm, but it's serial 0, and we only get PWM on 6 of the 8 pins at once.
 //  NOT_ON_TIMER, //see above.
 //  NOT_ON_TIMER,


### PR DESCRIPTION
Paraphrased from Table 12-7 on page 116 of ATtinyX41 datasheet:

**TOCC2** – OCnB
**TOCC3** – OCnA
**TOCC4** – OCnB
**TOCC5** – OCnA
**TOCC6** – OCnB
**TOCC7** – OCnA

Tough to remember, I know, but this could help: TOCC**odd** are channel **A**; TOCC**even** are channel **B**.
