### PR TITLE
Add support for "Export compiled binary"

### DIFF
--- a/avr/platform.txt
+++ b/avr/platform.txt
@@ -9,7 +9,7 @@ name=ATtiny Modern
 version=1.0.5
 
 # AVR compile variables
-# --------------------- 
+# ---------------------
 
 compiler.warning_flags=-w
 compiler.warning_flags.none=-w
@@ -72,6 +72,10 @@ recipe.objcopy.eep.pattern="{compiler.path}{compiler.objcopy.cmd}" {compiler.obj
 
 ## Create hex
 recipe.objcopy.hex.pattern="{compiler.path}{compiler.elf2hex.cmd}" {compiler.elf2hex.flags} {compiler.elf2hex.extra_flags} "{build.path}/{build.project_name}.elf" "{build.path}/{build.project_name}.hex"
+
+## Save hex
+recipe.output.tmp_file={build.project_name}.hex
+recipe.output.save_file={build.project_name}.hex
 
 ## Compute size
 recipe.size.pattern="{compiler.path}{compiler.size.cmd}" -A "{build.path}/{build.project_name}.elf"


### PR DESCRIPTION
Specify `recipe.output.tmp_file` and `recipe.output.save_file`
configurations to enable exporting a `.hex` file from the Arduino IDE.

Fixes the error `Warning: This core does not support exporting sketches.
Please consider upgrading it or contacting its author` shown when trying
to export a sketch.

<img width="304" alt="screen shot 2016-03-05 at 18 17 15" src="https://cloud.githubusercontent.com/assets/497214/13548682/83639286-e2fe-11e5-991f-c911d0da97d0.png">
