### PR TITLE
Fix deprecation warnings in Arduino IDE 1.6.7

### DIFF
--- a/avr/platform.txt
+++ b/avr/platform.txt
@@ -62,7 +62,7 @@ recipe.cpp.o.pattern="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} -m
 recipe.S.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.S.flags} -mmcu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.S.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{object_file}"
 
 ## Create archives
-recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} {compiler.ar.extra_flags} "{build.path}/{archive_file}" "{object_file}"
+recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} {compiler.ar.extra_flags} "{archive_file_path}" "{object_file}"
 
 ## Combine gc-sections, archives, and objects
 recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" {compiler.c.elf.flags} -mmcu={build.mcu} {compiler.c.elf.extra_flags} -o "{build.path}/{build.project_name}.elf" {object_files} "{build.path}/{archive_file}" "-L{build.path}" -lm
@@ -88,7 +88,7 @@ preproc.includes.flags=-w -x c++ -M -MG -MP
 recipe.preproc.includes="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} {preproc.includes.flags} -mmcu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} "{source_file}"
 
 preproc.macros.flags=-w -x c++ -E -CC
-recipe.preproc.macros="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} {preproc.macros.flags} -mmcu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} "{source_file}"
+recipe.preproc.macros="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} {preproc.macros.flags} -mmcu={build.mcu} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {includes} "{source_file}" -o "{preprocessed_file_path}"
 
 # AVR Uploader/Programmers tools
 # ------------------------------


### PR DESCRIPTION
- Fix `Warning: platform.txt from core 'ATtiny Modern' contains deprecated
  recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags}
  {compiler.ar.extra_flags} "{build.path}/{archive_file}" "{object_file}",
  automatically converted to
  recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags}
  {compiler.ar.extra_flags} "{archive_file_path}" "{object_file}". Consider
  upgrading this core.`
- Fix `Warning: platform.txt from core 'ATtiny Modern' contains deprecated
  recipe.preproc.macros="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags}
  {preproc.macros.flags} -mmcu={build.mcu} -DF_CPU={build.f_cpu}
  -DARDUINO={runtime.ide.version} -DARDUINO_{build.board}
  -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags}
  {includes} "{source_file}", automatically converted to
  recipe.preproc.macros="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags}
  {preproc.macros.flags} -mmcu={build.mcu} -DF_CPU={build.f_cpu}
  -DARDUINO={runtime.ide.version} -DARDUINO_{build.board}
  -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags}
  {includes} "{source_file}" -o "{preprocessed_file_path}". Consider upgrading
  this core.`
